### PR TITLE
Provide compatibility with IE11 for source maps.

### DIFF
--- a/Compiler/skc5/Compiler/SourceMapping/SkSourceMappingGenerator.cs
+++ b/Compiler/skc5/Compiler/SourceMapping/SkSourceMappingGenerator.cs
@@ -92,14 +92,14 @@ namespace SharpKit.Compiler.SourceMapping
                     }
                 }
             }
-            var v3Doc = doc.GenerateV3MappingDocs().SingleOrDefault();
+            var v3Doc = doc.GenerateV3MappingDocs("SourceMaps.ashx/").SingleOrDefault();
             if (v3Doc == null)
             {
                 Compiler.Log.WriteLine("Cannot generate source mapping file: " + mappingFilename + " - document not found");
                 return false;
             }
-            v3Doc.sourceRoot = "SourceMaps.ashx/";
             var tmpFilename = mappingFilename + ".tmp";
+            //v3Doc.sourceRoot = "SourceMaps.ashx/";
             v3Doc.SaveAs(tmpFilename);
             FileUtils.CompareAndSaveFile(mappingFilename, tmpFilename);
             if (CompilerConfiguration.Current.GenerateSourceMapsDebugFiles)

--- a/Compiler/skc5/Compiler/SourceMapping/SourceMapping.cs
+++ b/Compiler/skc5/Compiler/SourceMapping/SourceMapping.cs
@@ -11,7 +11,7 @@ namespace SharpKit.Compiler.SourceMapping
     [DataContract]
     class SourceMappingDocument
     {
-        public List<SourceMappingV3Document> GenerateV3MappingDocs()
+        public List<SourceMappingV3Document> GenerateV3MappingDocs(string sourceRoot)
         {
             var list = new List<SourceMappingV3Document>();
             var byGenFile = Mappings.GroupBy(t => t.GeneratedLocation.Filename).ToList();
@@ -25,7 +25,7 @@ namespace SharpKit.Compiler.SourceMapping
                 var sources = bySourceFile.Select(t => t.Key).ToList();
                 doc.sources = new List<string>();
                 foreach (var src in sources)
-                    doc.sources.Add(Path.GetFullPath(src).Replace("\\", "/"));
+                    doc.sources.Add(sourceRoot + Path.GetFullPath(src).Replace("\\", "/"));
                 var byGenLine = mappingsByGenFile.GroupBy(t => t.GeneratedLocation.Line).OrderBy(t => t.Key).ToList();
                 var prevSrcLine = 0;
                 var prevSrcColumn = 0;


### PR DESCRIPTION
Hello Dan-el,

IE11 can now use source maps (well, since last year). However it was not working with the file generated by SharpKit.
I have made some small changes to make it work, it is of course still compatible with Chrome and Firefox.

Basically I have included the source root at the beginning of every source file path.
It gives you something like that:
`..."sourceRoot":"","sources":["SourceMaps.ashx/C:/Dev/Windows/Ja...`

For what I have understood, IE looks at the value in the sourceroot property, but the fact that the file names starts with a drive name (i.e. C:/...) seems to confuse him.

I was actually trying to make the debugging works from within Visual Studio (it would have been great, don't you think?) but I couldn't achieve that.
If you remove completely the sourceroot content (just leaving the full path of the files), the browser cannot find anymore the source files but Visual studio does make the link when you start a debug session with IE. However, it does not allow to put a breakpoint in the cs files. 
Maybe a bit more digging could do it, I'll try when I have time.

Regards,

Olivier